### PR TITLE
4: PostgreSQLと接続し、ユーザーテーブルを作成する 

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,0 +1,38 @@
+"""データベース接続設定
+
+最低限のSQLAlchemy設定
+"""
+
+from typing import Generator
+from sqlalchemy import create_engine
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker, Session
+
+# データベース接続URL
+DATABASE_URL = "postgresql://user:password@db:5432/fastapi-test"
+
+# SQLAlchemyエンジンの作成
+engine = create_engine(DATABASE_URL)
+
+# セッションファクトリーの作成
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+# Baseクラス
+Base = declarative_base()
+
+
+def get_db() -> Generator[Session, None, None]:
+    """データベースセッションを取得する依存性注入関数"""
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def create_tables():
+    """テーブルを作成する関数"""
+    # モデルをインポートしてテーブルを作成
+    from models.user import User
+
+    Base.metadata.create_all(bind=engine)

--- a/config.py
+++ b/config.py
@@ -33,6 +33,6 @@ def get_db() -> Generator[Session, None, None]:
 def create_tables():
     """テーブルを作成する関数"""
     # モデルをインポートしてテーブルを作成
-    from models.user import User
+    from models.user import User  # noqa: F401
 
     Base.metadata.create_all(bind=engine)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,3 +10,29 @@ services:
     environment:
       - PYTHONUNBUFFERED=1
     restart: unless-stopped
+
+  db:
+    image: postgres:15
+    environment:
+      - POSTGRES_DB=fastapi-test
+      - POSTGRES_USER=user
+      - POSTGRES_PASSWORD=password
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    restart: unless-stopped
+
+  pgadmin:
+    image: dpage/pgadmin4:latest
+    environment:
+      - PGADMIN_DEFAULT_EMAIL=admin@example.com
+      - PGADMIN_DEFAULT_PASSWORD=password
+    ports:
+      - "8080:80"
+    depends_on:
+      - db
+    restart: unless-stopped
+
+volumes:
+  postgres_data:

--- a/main.py
+++ b/main.py
@@ -1,7 +1,15 @@
 from fastapi import FastAPI
 from pydantic import BaseModel
+from config import create_tables
+from routers import users
 
 app = FastAPI()
+
+
+# アプリケーション起動時にテーブルを作成
+@app.on_event("startup")
+async def startup_event():
+    create_tables()
 
 
 class AddRequest(BaseModel):
@@ -24,3 +32,7 @@ def add_numbers(request: AddRequest):
         "result": result,
         "message": f"{request.a} + {request.b} = {result}",
     }
+
+
+# ルーターの登録
+app.include_router(users.router)

--- a/models/user.py
+++ b/models/user.py
@@ -1,0 +1,39 @@
+"""ユーザーモデル
+
+ユーザー情報を管理するSQLAlchemyモデルです。
+"""
+
+from sqlalchemy import Column, Integer, String, Index
+from config import Base
+
+
+class User(Base):
+    """ユーザーモデルクラス
+
+    Attributes:
+        id: プライマリキー
+        name: ユーザー名（ユニーク）
+        email: メールアドレス（ユニーク）
+        password: パスワード（ハッシュ化済み）
+    """
+
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(50), unique=True, nullable=False)
+    email = Column(String(100), unique=True, nullable=False)
+    password = Column(String(255), nullable=False)
+
+    # インデックスを定義
+    __table_args__ = (
+        Index("idx_users_name", "name"),
+        Index("idx_users_email", "email"),
+    )
+
+    def __repr__(self):
+        """文字列表現を返す
+
+        Returns:
+            str: ユーザーの文字列表現
+        """
+        return f"<User(id={self.id}, name='{self.name}', email='{self.email}')>"

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,7 @@ pytest==7.4.3
 pytest-cov==4.1.0
 flake8==6.1.0
 httpx==0.25.2 
+psycopg2-binary==2.9.9
+sqlalchemy==2.0.23
+pydantic-settings==2.0.0
+passlib[bcrypt]>=1.7.4

--- a/routers/users.py
+++ b/routers/users.py
@@ -1,0 +1,71 @@
+"""ユーザー関連のAPIエンドポイント
+
+PostgreSQLを使用したユーザー管理のためのREST APIエンドポイントです。
+ユーザー情報、認証情報などの構造化データを管理します。
+"""
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+from sqlalchemy.exc import IntegrityError
+
+from config import get_db
+from schemas.users import UserCreate, UserResponse
+from services.users import UserService
+
+# ユーザー管理用ルーター
+router = APIRouter(
+    prefix="/api/users",
+    tags=["users"],
+    responses={404: {"description": "Not found"}},
+)
+
+
+@router.post(
+    "/",
+    response_model=UserResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="ユーザー登録",
+    description="新しいユーザーを登録します。パスワードは自動的にハッシュ化されます。",
+    response_description="作成されたユーザー情報",
+)
+async def create_user(
+    user_data: UserCreate,  # リクエストボディ（Pydanticで自動バリデーション）
+    db: Session = Depends(get_db),  # データベースセッション（依存性注入）
+) -> UserResponse:
+    """ユーザーを作成する
+
+    Args:
+        user_data: ユーザー作成データ（自動的にバリデーション済み）
+        db: データベースセッション（依存性注入）
+
+    Returns:
+        UserResponse: 作成されたユーザー情報
+
+    Raises:
+        HTTPException: ユーザー名またはメールアドレスが重複している場合（400）
+    """
+
+    # 1. ユーザー名の重複チェック
+    if UserService.is_name_taken(db, user_data.name):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"ユーザー名 '{user_data.name}' は既に使用されています",
+        )
+
+    # 2. メールアドレスの重複チェック
+    if UserService.is_email_taken(db, user_data.email):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"メールアドレス '{user_data.email}' は既に使用されています",
+        )
+
+    # 3. ユーザー作成
+    try:
+        db_user = UserService.create_user(db, user_data)
+        return UserResponse.model_validate(db_user)
+    except IntegrityError:
+        # データベースレベルでの制約違反（念のため）
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="ユーザー名またはメールアドレスが既に使用されています",
+        )

--- a/schemas/users.py
+++ b/schemas/users.py
@@ -1,0 +1,61 @@
+"""ユーザー関連のPydanticスキーマ
+
+リクエスト/レスポンスのバリデーションとシリアライゼーションを行います。
+"""
+
+from pydantic import BaseModel, Field
+
+
+class UserCreate(BaseModel):
+    """ユーザー作成用スキーマ
+
+    POSTリクエストで受け取るデータの形式を定義します。
+
+    Attributes:
+        name: ユーザー名（必須、3-50文字）
+        email: メールアドレス（必須、有効なメール形式）
+        password: パスワード（必須、8文字以上）
+    """
+
+    name: str = Field(..., min_length=3, max_length=50, description="ユーザー名")
+    email: str = Field(..., description="メールアドレス")
+    password: str = Field(..., min_length=8, description="パスワード")
+
+    class Config:
+        """設定クラス"""
+
+        # JSON Schema用のサンプルデータ
+        json_schema_extra = {
+            "example": {
+                "name": "user",
+                "email": "user@example.com",
+                "password": "P@ssw0rd",
+            }
+        }
+
+
+class UserResponse(BaseModel):
+    """ユーザーレスポンス用スキーマ
+
+    APIレスポンスで返すデータの形式を定義します。
+    セキュリティのためパスワードは含めません。
+
+    Attributes:
+        id: ユーザーID
+        name: ユーザー名
+        email: メールアドレス
+    """
+
+    id: int
+    name: str
+    email: str
+
+    class Config:
+        """設定クラス"""
+
+        from_attributes = True  # SQLAlchemyモデルからの変換を有効化
+
+        # JSON Schema用のサンプルデータ
+        json_schema_extra = {
+            "example": {"id": 1, "name": "user", "email": "user@example.com"}
+        }

--- a/services/users.py
+++ b/services/users.py
@@ -1,0 +1,131 @@
+"""ユーザーサービス
+
+ユーザー関連のビジネスロジックを処理します。
+"""
+
+from typing import Optional
+from sqlalchemy.orm import Session
+from sqlalchemy.exc import IntegrityError
+from passlib.context import CryptContext
+from models.user import User
+from schemas.users import UserCreate
+
+# パスワードハッシュ化用の設定
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+class UserService:
+    """ユーザーサービスクラス
+
+    データベース操作とビジネスルールの実装を担当。
+    """
+
+    @staticmethod
+    def create_user(db: Session, user_data: UserCreate) -> User:
+        """ユーザーを作成する
+
+        Args:
+            db: データベースセッション
+            user_data: ユーザー作成データ
+
+        Returns:
+            User: 作成されたユーザーオブジェクト
+
+        Raises:
+            IntegrityError: ユーザー名またはメールアドレスが重複している場合
+        """
+        # パスワードをハッシュ化
+        hashed_password = pwd_context.hash(user_data.password)
+
+        # SQLAlchemyモデルインスタンスの作成
+        db_user = User(
+            name=user_data.name, email=user_data.email, password=hashed_password
+        )
+
+        try:
+            # データベースに追加
+            db.add(db_user)
+            db.commit()
+            db.refresh(db_user)  # 自動生成されたIDなどを取得
+            return db_user
+        except IntegrityError:
+            db.rollback()
+            raise
+
+    @staticmethod
+    def get_user_by_id(db: Session, user_id: int) -> Optional[User]:
+        """IDでユーザーを取得する
+
+        Args:
+            db: データベースセッション
+            user_id: ユーザーID
+
+        Returns:
+            Optional[User]: ユーザーオブジェクト（存在しない場合はNone）
+        """
+        return db.query(User).filter(User.id == user_id).first()
+
+    @staticmethod
+    def get_user_by_name(db: Session, name: str) -> Optional[User]:
+        """ユーザー名でユーザーを取得する
+
+        Args:
+            db: データベースセッション
+            name: ユーザー名
+
+        Returns:
+            Optional[User]: ユーザーオブジェクト（存在しない場合はNone）
+        """
+        return db.query(User).filter(User.name == name).first()
+
+    @staticmethod
+    def get_user_by_email(db: Session, email: str) -> Optional[User]:
+        """メールアドレスでユーザーを取得する
+
+        Args:
+            db: データベースセッション
+            email: メールアドレス
+
+        Returns:
+            Optional[User]: ユーザーオブジェクト（存在しない場合はNone）
+        """
+        return db.query(User).filter(User.email == email).first()
+
+    @staticmethod
+    def is_name_taken(db: Session, name: str) -> bool:
+        """ユーザー名が既に使用されているかチェックする
+
+        Args:
+            db: データベースセッション
+            name: チェックするユーザー名
+
+        Returns:
+            bool: 使用済みの場合True、利用可能な場合False
+        """
+        return UserService.get_user_by_name(db, name) is not None
+
+    @staticmethod
+    def is_email_taken(db: Session, email: str) -> bool:
+        """メールアドレスが既に使用されているかチェックする
+
+        Args:
+            db: データベースセッション
+            email: チェックするメールアドレス
+
+        Returns:
+            bool: 使用済みの場合True、利用可能な場合False
+        """
+        return UserService.get_user_by_email(db, email) is not None
+
+    @staticmethod
+    def verify_password(plain_password: str, hashed_password: str) -> bool:
+        """パスワードを検証する
+
+        Args:
+            plain_password: 平文パスワード
+            hashed_password: ハッシュ化済みパスワード
+
+        Returns:
+            bool: パスワードが一致する場合True
+        """
+        return pwd_context.verify(plain_password, hashed_password)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,36 @@
+"""
+Pytest設定とフィクスチャ
+
+FastAPIアプリケーションのテスト用設定とフィクスチャを定義します。
+
+注意事項:
+    ファイル名'conftest.py'はpytestの規約で固定されており、変更できません。
+    pytestがこのファイルを自動で発見・読み込みします。
+
+実行方法:
+    cd backend
+    pip install -r requirements.txt
+    python -m pytest tests/test_health.py -v
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+from main import app
+
+
+@pytest.fixture
+def client():
+    """FastAPIアプリケーション用のテストクライアントを作成
+
+    FastAPIアプリケーションに対してHTTPリクエストを送信するための
+    TestClientインスタンスを提供するフィクスチャです。
+
+    Returns:
+        TestClient: 設定済みのFastAPIアプリ用テストクライアント
+
+    使用例:
+        def test_endpoint(client):
+            response = client.get("/")
+            assert response.status_code == 200
+    """
+    return TestClient(app)

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -1,0 +1,257 @@
+"""
+ユーザー関連エンドポイントのテストモジュール
+
+テスト実行方法:
+1. コマンドラインからの実行:
+    python -m pytest -v tests/
+    python -m pytest -v tests/test_users.py
+
+2. 特定のテストメソッドだけ実行:
+    python -m pytest -v \
+        tests/test_users.py::TestCreateUser::test_create_user_success
+    python -m pytest -v tests/test_users.py::TestGetUser::test_get_user_success
+
+3. カバレッジレポート生成:
+    coverage run -m pytest tests/
+    coverage report
+    coverage html
+"""
+
+from unittest.mock import MagicMock
+from fastapi.testclient import TestClient
+from sqlalchemy.exc import IntegrityError
+
+from main import app
+from config import get_db
+from models.user import User
+from services.users import UserService
+
+
+class TestCreateUser:
+    """ユーザー作成エンドポイントのテストクラス"""
+
+    def test_create_user_success(self, client: TestClient):
+        """ユーザー作成の正常系テスト
+
+        正常なユーザーデータを送信した際に、適切なレスポンスが返されることを検証します。
+        """
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # モックユーザーオブジェクト
+        mock_user = User(
+            id=1, name="testuser", email="test@example.com", password="hashed_password"
+        )
+
+        # UserServiceのメソッドをモック化
+        UserService.is_name_taken = MagicMock(return_value=False)
+        UserService.is_email_taken = MagicMock(return_value=False)
+        UserService.create_user = MagicMock(return_value=mock_user)
+
+        # データベースセッションをオーバーライド
+        def override_get_db():
+            yield mock_db
+
+        # データベースセッションをオーバーライド
+        app.dependency_overrides[get_db] = override_get_db
+
+        try:
+            # テストデータ
+            request_data = {
+                "name": "testuser",
+                "email": "test@example.com",
+                "password": "password123",
+            }
+
+            # APIリクエストを送信
+            response = client.post("/api/users/", json=request_data)
+
+            # レスポンスの検証
+            assert response.status_code == 201
+            response_data = response.json()
+            assert response_data["id"] == 1
+            assert response_data["name"] == "testuser"
+            assert response_data["email"] == "test@example.com"
+            assert "password" not in response_data  # パスワードは含まれない
+
+            # サービスメソッドの呼び出し確認
+            UserService.is_name_taken.assert_called_once_with(mock_db, "testuser")
+            UserService.is_email_taken.assert_called_once_with(
+                mock_db, "test@example.com"
+            )
+            UserService.create_user.assert_called_once()
+
+        finally:
+            # オーバーライドとモックをクリア
+            app.dependency_overrides.clear()
+            UserService.is_name_taken.reset_mock()
+            UserService.is_email_taken.reset_mock()
+            UserService.create_user.reset_mock()
+
+    def test_create_user_duplicate_name(self, client: TestClient):
+        """ユーザー作成の異常系テスト（重複するユーザー名）
+
+        既に存在するユーザー名を使用した場合のエラーハンドリングを検証します。
+        """
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # UserServiceのメソッドをモック化（ユーザー名重複）
+        UserService.is_name_taken = MagicMock(return_value=True)
+        UserService.is_email_taken = MagicMock(return_value=False)
+
+        # データベースセッションをオーバーライド
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        try:
+            # テストデータ
+            request_data = {
+                "name": "existinguser",
+                "email": "new@example.com",
+                "password": "password123",
+            }
+
+            # APIリクエストを送信
+            response = client.post("/api/users/", json=request_data)
+
+            # エラーレスポンスの検証
+            assert response.status_code == 400
+            response_data = response.json()
+            assert "existinguser" in response_data["detail"]
+            assert "既に使用されています" in response_data["detail"]
+
+        finally:
+            # オーバーライドとモックをクリア
+            app.dependency_overrides.clear()
+            UserService.is_name_taken.reset_mock()
+            UserService.is_email_taken.reset_mock()
+
+    def test_create_user_duplicate_email(self, client: TestClient):
+        """ユーザー作成の異常系テスト（重複するメールアドレス）
+
+        既に存在するメールアドレスを使用した場合のエラーハンドリングを検証します。
+        """
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # UserServiceのメソッドをモック化（メール重複）
+        UserService.is_name_taken = MagicMock(return_value=False)
+        UserService.is_email_taken = MagicMock(return_value=True)
+
+        # データベースセッションをオーバーライド
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        try:
+            # テストデータ
+            request_data = {
+                "name": "newuser",
+                "email": "existing@example.com",
+                "password": "password123",
+            }
+
+            # APIリクエストを送信
+            response = client.post("/api/users/", json=request_data)
+
+            # エラーレスポンスの検証
+            assert response.status_code == 400
+            response_data = response.json()
+            assert "existing@example.com" in response_data["detail"]
+            assert "既に使用されています" in response_data["detail"]
+
+        finally:
+            # オーバーライドとモックをクリア
+            app.dependency_overrides.clear()
+            UserService.is_name_taken.reset_mock()
+            UserService.is_email_taken.reset_mock()
+
+    def test_create_user_invalid_data(self, client: TestClient):
+        """ユーザー作成の異常系テスト（不正なデータ）
+
+        バリデーションエラーが発生するデータを送信した場合のエラーハンドリングを検証します。
+        """
+        # 不正なリクエストデータ（nameフィールドが不足）
+        invalid_request_data = {"email": "test@example.com", "password": "password123"}
+
+        # APIリクエストを送信
+        response = client.post("/api/users/", json=invalid_request_data)
+
+        # バリデーションエラーの検証
+        assert response.status_code == 422
+        response_data = response.json()
+        assert "detail" in response_data
+
+        # nameフィールドが不足している旨のエラーを確認
+        errors = response_data["detail"]
+        assert any(error["loc"] == ["body", "name"] for error in errors)
+
+    def test_create_user_short_password(self, client: TestClient):
+        """ユーザー作成の異常系テスト（短すぎるパスワード）
+
+        パスワードが8文字未満の場合のバリデーションエラーを検証します。
+        """
+        # 短いパスワードのテストデータ
+        request_data = {
+            "name": "testuser",
+            "email": "test@example.com",
+            "password": "123",  # 8文字未満
+        }
+
+        # APIリクエストを送信
+        response = client.post("/api/users/", json=request_data)
+
+        # バリデーションエラーの検証
+        assert response.status_code == 422
+        response_data = response.json()
+        assert "detail" in response_data
+
+        # パスワードの長さに関するエラーを確認
+        errors = response_data["detail"]
+        assert any(error["loc"] == ["body", "password"] for error in errors)
+
+    def test_create_user_integrity_error(self, client: TestClient):
+        """ユーザー作成の異常系テスト（データベース制約エラー）
+
+        データベースレベルでの制約違反が発生した場合のエラーハンドリングを検証します。
+        """
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # UserServiceのメソッドをモック化
+        UserService.is_name_taken = MagicMock(return_value=False)
+        UserService.is_email_taken = MagicMock(return_value=False)
+        UserService.create_user = MagicMock(side_effect=IntegrityError("", "", ""))
+
+        # データベースセッションをオーバーライド
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        try:
+            # テストデータ
+            request_data = {
+                "name": "testuser",
+                "email": "test@example.com",
+                "password": "password123",
+            }
+
+            # APIリクエストを送信
+            response = client.post("/api/users/", json=request_data)
+
+            # エラーレスポンスの検証
+            assert response.status_code == 400
+            response_data = response.json()
+            assert "既に使用されています" in response_data["detail"]
+
+        finally:
+            # オーバーライドとモックをクリア
+            app.dependency_overrides.clear()
+            UserService.is_name_taken.reset_mock()
+            UserService.is_email_taken.reset_mock()
+            UserService.create_user.reset_mock()


### PR DESCRIPTION
# enhancement

## 概要

<!-- このPull Requestで対応する目的や背景を記述してください -->
FastAPIとPostgreSQLを接続し、アプリケーション側からユーザー情報を登録できるようにする。まずはデータ登録のみをスコープとする。

## 実装内容

<!-- 実装した主な内容を箇条書きで記述してください -->
- ユーザーテーブルの定義
- ユーザー登録APIエンドポイントの追加
- bcryptによるパスワードハッシュ化
- データ永続化

## 動作確認

<!-- 手動または自動で確認した手順を記述してください -->
- [x]  ユーザー登録APIで新規ユーザーを作成できる
- [x]  重複するユーザー名・メールアドレスでの登録時に適切なエラーが返される
- [x] パスワードがハッシュ化されてデータベースに保存される
- [x] データがDocker Composeのボリュームに永続化される

## 関連 Issue

<!-- 関連するIssueがあれば記載してください -->
[4: PostgreSQLと接続し、ユーザーテーブルを作成する ](https://github.com/ymtdir/fastapi-test/issues/7)

## 補足

<!-- その他共有事項や注意点があれば記載してください -->
特に無し

