### PR TITLE
#5: 認証機能の実装

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,15 +1,42 @@
-"""データベース接続設定
+"""アプリ設定とデータベース接続設定
 
-最低限のSQLAlchemy設定
+環境変数から設定を読み込み、SQLAlchemyの最低限のセットアップを提供します。
 """
 
 from typing import Generator
+from pydantic import Field
+from pydantic_settings import BaseSettings
 from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker, Session
 
+
+class Settings(BaseSettings):
+    """アプリ全体の設定
+
+    環境変数から値を読み込みます。存在しない場合はデフォルトを使用します。
+    """
+
+    # JWT関連
+    secret_key: str = Field("change_me", env="SECRET_KEY")
+    algorithm: str = Field("HS256", env="ALGORITHM")
+    access_token_expire_minutes: int = Field(30, env="ACCESS_TOKEN_EXPIRE_MINUTES")
+
+    # DB関連
+    database_url: str = Field(
+        "postgresql://user:password@db:5432/fastapi-test", env="DATABASE_URL"
+    )
+
+    class Config:
+        env_file = ".env"
+        extra = "ignore"
+
+
+# グローバル設定インスタンス
+settings = Settings()
+
 # データベース接続URL
-DATABASE_URL = "postgresql://user:password@db:5432/fastapi-test"
+DATABASE_URL = settings.database_url
 
 # SQLAlchemyエンジンの作成
 engine = create_engine(DATABASE_URL)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     image: postgres:15
     environment:
       - POSTGRES_DB=fastapi-test
-      - POSTGRES_USER=user
+      - POSTGRES_USER=admin
       - POSTGRES_PASSWORD=password
     ports:
       - "5432:5432"
@@ -28,11 +28,15 @@ services:
     environment:
       - PGADMIN_DEFAULT_EMAIL=admin@example.com
       - PGADMIN_DEFAULT_PASSWORD=password
+      - PGADMIN_CONFIG_MASTER_PASSWORD_REQUIRED=False
     ports:
       - "8080:80"
     depends_on:
       - db
     restart: unless-stopped
+    volumes:
+      - pgadmin_data:/var/lib/pgadmin # ← pgAdmin の設定/保存済み接続を永続化
 
 volumes:
   postgres_data:
+  pgadmin_data:

--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from pydantic import BaseModel
 from config import create_tables
-from routers import users
+from routers import users, auth
 
 app = FastAPI()
 
@@ -36,3 +36,4 @@ def add_numbers(request: AddRequest):
 
 # ルーターの登録
 app.include_router(users.router)
+app.include_router(auth.router)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ psycopg2-binary==2.9.9
 sqlalchemy==2.0.23
 pydantic-settings==2.0.0
 passlib[bcrypt]>=1.7.4
+python-jose[cryptography]>=3.3.0
+email-validator>=2.1.0

--- a/routers/auth.py
+++ b/routers/auth.py
@@ -1,0 +1,55 @@
+"""認証関連のルーター
+
+ログイン・ログアウトなどの認証機能を提供します。
+"""
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+from config import get_db
+from schemas.auth import UserLogin, Token
+from services.auth import AuthService
+
+router = APIRouter(prefix="/api/auth", tags=["auth"])
+
+
+@router.post("/login", response_model=Token)
+async def login(user_login: UserLogin, db: Session = Depends(get_db)):
+    """ユーザーログイン
+
+    Args:
+        user_login: ログインデータ
+        db: データベースセッション
+
+    Returns:
+        Token: アクセストークンとトークンタイプ
+
+    Raises:
+        HTTPException: 認証失敗時
+    """
+    try:
+        result = AuthService.login_user(db, user_login)
+        return Token(
+            access_token=result["access_token"], token_type=result["token_type"]
+        )
+    except HTTPException:
+        raise
+    except Exception:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="ログイン処理中にエラーが発生しました",
+        )
+
+
+@router.post("/logout")
+async def logout():
+    """ユーザーログアウト
+
+    注意: JWTはステートレスなので、サーバー側での処理は不要です。
+    クライアント側でトークンを削除してください。
+
+    Returns:
+        dict: ログアウト成功メッセージ
+    """
+    return {
+        "message": "ログアウトしました。クライアント側でトークンを削除してください。"
+    }

--- a/schemas/auth.py
+++ b/schemas/auth.py
@@ -1,0 +1,69 @@
+"""認証関連のPydanticスキーマ
+
+JWT認証とログイン機能のリクエスト/レスポンスのバリデーションとシリアライゼーションを行います。
+"""
+
+from typing import Optional
+from pydantic import BaseModel, Field, EmailStr
+
+
+class UserLogin(BaseModel):
+    """ユーザーログイン用スキーマ
+
+    POSTリクエストで受け取るログインデータの形式を定義します。
+
+    Attributes:
+        email: メールアドレス（必須、有効なメール形式）
+        password: パスワード（必須）
+    """
+
+    email: EmailStr = Field(..., description="メールアドレス")
+    password: str = Field(..., description="パスワード")
+
+    class Config:
+        """設定クラス"""
+
+        # JSON Schema用のサンプルデータ
+        json_schema_extra = {
+            "example": {
+                "email": "user@example.com",
+                "password": "P@ssw0rd",
+            }
+        }
+
+
+class Token(BaseModel):
+    """認証トークン用スキーマ
+
+    JWTトークンのレスポンス形式を定義します。
+
+    Attributes:
+        access_token: アクセストークン
+        token_type: トークンタイプ（通常は"bearer"）
+    """
+
+    access_token: str = Field(..., description="アクセストークン")
+    token_type: str = Field(default="bearer", description="トークンタイプ")
+
+    class Config:
+        """設定クラス"""
+
+        # JSON Schema用のサンプルデータ
+        json_schema_extra = {
+            "example": {
+                "access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+                "token_type": "bearer",
+            }
+        }
+
+
+class TokenData(BaseModel):
+    """トークンデータ用スキーマ
+
+    JWTトークンに含まれるデータの形式を定義します。
+
+    Attributes:
+        email: メールアドレス（オプション）
+    """
+
+    email: Optional[str] = None

--- a/services/auth.py
+++ b/services/auth.py
@@ -1,0 +1,149 @@
+"""認証サービス
+
+JWT認証とログイン機能を処理します。
+"""
+
+from datetime import datetime, timedelta
+from typing import Optional
+from sqlalchemy.orm import Session
+from jose import JWTError, jwt
+from fastapi import HTTPException, status, Header
+from models.user import User
+from schemas.auth import UserLogin, TokenData
+from .users import UserService
+from config import settings
+
+# JWT設定
+SECRET_KEY = settings.secret_key
+ALGORITHM = settings.algorithm
+ACCESS_TOKEN_EXPIRE_MINUTES = settings.access_token_expire_minutes
+
+
+class AuthService:
+    """認証サービスクラス
+
+    JWT認証とログイン機能の実装を担当。
+    """
+
+    @staticmethod
+    def get_token_from_header(
+        authorization: Optional[str] = Header(None),
+    ) -> Optional[str]:
+        """Authorizationヘッダーからトークンを取得する
+
+        Args:
+            authorization: Authorizationヘッダーの値
+
+        Returns:
+            Optional[str]: トークン（Bearer プレフィックスを除いたもの）
+        """
+        if not authorization:
+            return None
+
+        if not authorization.startswith("Bearer "):
+            return None
+
+        return authorization.replace("Bearer ", "")
+
+    @staticmethod
+    def authenticate_user(db: Session, email: str, password: str) -> Optional[User]:
+        """ユーザー認証を行う
+
+        Args:
+            db: データベースセッション
+            email: メールアドレス
+            password: パスワード
+
+        Returns:
+            Optional[User]: 認証成功時はユーザーオブジェクト、失敗時はNone
+        """
+        # メールアドレスでユーザーを取得
+        user = UserService.get_user_by_email(db, email)
+        if not user:
+            return None
+
+        # パスワードを検証
+        if not UserService.verify_password(password, user.password):
+            return None
+
+        return user
+
+    @staticmethod
+    def create_access_token(
+        data: dict, expires_delta: Optional[timedelta] = None
+    ) -> str:
+        """アクセストークンを作成する
+
+        Args:
+            data: トークンに含めるデータ
+            expires_delta: 有効期限（指定しない場合はデフォルト値を使用）
+
+        Returns:
+            str: JWTアクセストークン
+        """
+        to_encode = data.copy()
+
+        if expires_delta:
+            expire = datetime.utcnow() + expires_delta
+        else:
+            expire = datetime.utcnow() + timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+
+        to_encode.update({"exp": expire})
+        encoded_jwt = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+
+        return encoded_jwt
+
+    @staticmethod
+    def verify_token(token: str) -> Optional[TokenData]:
+        """トークンを検証する
+
+        Args:
+            token: JWTトークン
+
+        Returns:
+            Optional[TokenData]: 検証成功時はトークンデータ、失敗時はNone
+        """
+        try:
+            payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+            email: str = payload.get("sub")
+            if email is None:
+                return None
+            token_data = TokenData(email=email)
+            return token_data
+        except JWTError:
+            return None
+
+    @staticmethod
+    def login_user(db: Session, user_login: UserLogin) -> dict:
+        """ユーザーログインを処理する
+
+        Args:
+            db: データベースセッション
+            user_login: ログインデータ
+
+        Returns:
+            dict: アクセストークンとトークンタイプを含む辞書
+
+        Raises:
+            HTTPException: 認証失敗時
+        """
+        # ユーザー認証
+        user = AuthService.authenticate_user(db, user_login.email, user_login.password)
+        if not user:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="メールアドレスまたはパスワードが正しくありません",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+
+        # アクセストークンを作成
+        access_token_expires = timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+        access_token = AuthService.create_access_token(
+            data={"sub": user.email}, expires_delta=access_token_expires
+        )
+
+        return {
+            "access_token": access_token,
+            "token_type": "bearer",
+            "user": {"id": user.id, "name": user.name, "email": user.email},
+        }

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,386 @@
+"""
+認証関連エンドポイントのテストモジュール
+
+テスト実行方法:
+1. コマンドラインからの実行:
+    python -m pytest -v tests/
+    python -m pytest -v tests/test_auth.py
+
+2. 特定のテストメソッドだけ実行:
+    python -m pytest -v \
+        tests/test_auth.py::TestLogin::test_login_success
+    python -m pytest -v tests/test_auth.py::TestLogout::test_logout_success
+
+3. カバレッジレポート生成:
+    coverage run -m pytest tests/
+    coverage report
+    coverage html
+"""
+
+from unittest.mock import MagicMock, patch
+from fastapi.testclient import TestClient
+
+from main import app
+from config import get_db
+from models.user import User
+from services.auth import AuthService
+from services.users import UserService
+
+
+class TestLogin:
+    """ログインエンドポイントのテストクラス"""
+
+    def test_login_success(self, client: TestClient):
+        """ログインの正常系テスト
+
+        正しい認証情報を送信した際に、適切なJWTトークンが返されることを検証します。
+        """
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # モックユーザーオブジェクト（未使用のため削除）
+
+        # AuthServiceのメソッドをモック化
+        with patch("services.auth.AuthService.login_user") as mock_login:
+            mock_login.return_value = {
+                "access_token": "mock_jwt_token",
+                "token_type": "bearer",
+            }
+
+            # データベースセッションをオーバーライド
+            def override_get_db():
+                yield mock_db
+
+            app.dependency_overrides[get_db] = override_get_db
+
+            try:
+                # テストデータ
+                request_data = {
+                    "email": "test@example.com",
+                    "password": "password123",
+                }
+
+                # APIリクエストを送信
+                response = client.post("/api/auth/login", json=request_data)
+
+                # レスポンスの検証
+                assert response.status_code == 200
+                response_data = response.json()
+                assert "access_token" in response_data
+                assert response_data["token_type"] == "bearer"
+                assert response_data["access_token"] == "mock_jwt_token"
+
+                # サービスメソッドの呼び出し確認
+                mock_login.assert_called_once()
+
+            finally:
+                # オーバーライドとモックをクリア
+                app.dependency_overrides.clear()
+
+    def test_login_invalid_credentials(self, client: TestClient):
+        """ログインの異常系テスト（無効な認証情報）
+
+        間違った認証情報を送信した際のエラーハンドリングを検証します。
+        """
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # AuthServiceのメソッドをモック化（認証失敗）
+        AuthService.authenticate_user = MagicMock(return_value=None)
+
+        # データベースセッションをオーバーライド
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        try:
+            # テストデータ
+            request_data = {
+                "email": "test@example.com",
+                "password": "wrongpassword",
+            }
+
+            # APIリクエストを送信
+            response = client.post("/api/auth/login", json=request_data)
+
+            # レスポンスの検証
+            assert response.status_code == 401
+            response_data = response.json()
+            assert "detail" in response_data
+            assert (
+                "メールアドレスまたはパスワードが正しくありません"
+                in response_data["detail"]
+            )
+
+            # サービスメソッドの呼び出し確認
+            AuthService.authenticate_user.assert_called_once_with(
+                mock_db, "test@example.com", "wrongpassword"
+            )
+
+        finally:
+            # オーバーライドとモックをクリア
+            app.dependency_overrides.clear()
+            AuthService.authenticate_user.reset_mock()
+
+    def test_login_invalid_email_format(self, client: TestClient):
+        """ログインの異常系テスト（無効なメール形式）
+
+        無効なメールアドレス形式を送信した際のバリデーションエラーを検証します。
+        """
+        # テストデータ（無効なメール形式）
+        request_data = {
+            "email": "invalid-email",
+            "password": "password123",
+        }
+
+        # APIリクエストを送信
+        response = client.post("/api/auth/login", json=request_data)
+
+        # レスポンスの検証
+        assert response.status_code == 422  # Validation Error
+        response_data = response.json()
+        assert "detail" in response_data
+
+    def test_login_missing_fields(self, client: TestClient):
+        """ログインの異常系テスト（必須フィールドの欠落）
+
+        必須フィールドが欠落している場合のバリデーションエラーを検証します。
+        """
+        # テストデータ（パスワードが欠落）
+        request_data = {
+            "email": "test@example.com",
+        }
+
+        # APIリクエストを送信
+        response = client.post("/api/auth/login", json=request_data)
+
+        # レスポンスの検証
+        assert response.status_code == 422  # Validation Error
+        response_data = response.json()
+        assert "detail" in response_data
+
+    def test_login_empty_fields(self, client: TestClient):
+        """ログインの異常系テスト（空のフィールド）
+
+        空のフィールドを送信した際のバリデーションエラーを検証します。
+        """
+        # テストデータ（空のフィールド）
+        request_data = {
+            "email": "",
+            "password": "",
+        }
+
+        # APIリクエストを送信
+        response = client.post("/api/auth/login", json=request_data)
+
+        # レスポンスの検証
+        assert response.status_code == 422  # Validation Error
+        response_data = response.json()
+        assert "detail" in response_data
+
+
+class TestLogout:
+    """ログアウトエンドポイントのテストクラス"""
+
+    def test_logout_success(self, client: TestClient):
+        """ログアウトの正常系テスト
+
+        ログアウトエンドポイントが正常に応答することを検証します。
+        """
+        # APIリクエストを送信
+        response = client.post("/api/auth/logout")
+
+        # レスポンスの検証
+        assert response.status_code == 200
+        response_data = response.json()
+        assert "message" in response_data
+        assert "ログアウトしました" in response_data["message"]
+
+
+class TestAuthService:
+    """認証サービスのテストクラス"""
+
+    def test_authenticate_user_success(self):
+        """ユーザー認証の正常系テスト
+
+        正しい認証情報でユーザーが認証されることを検証します。
+        """
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # モックユーザーオブジェクト
+        mock_user = User(
+            id=1, name="testuser", email="test@example.com", password="hashed_password"
+        )
+
+        # AuthService.authenticate_userメソッド全体をモック化
+        with patch.object(AuthService, "authenticate_user") as mock_authenticate:
+            mock_authenticate.return_value = mock_user
+
+            # 認証テスト
+            result = AuthService.authenticate_user(
+                mock_db, "test@example.com", "password123"
+            )
+
+            # 結果の検証
+            assert result == mock_user
+            mock_authenticate.assert_called_once_with(
+                mock_db, "test@example.com", "password123"
+            )
+
+    def test_authenticate_user_invalid_email(self):
+        """ユーザー認証の異常系テスト（存在しないメールアドレス）
+
+        存在しないメールアドレスで認証が失敗することを検証します。
+        """
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # AuthService.authenticate_userメソッド全体をモック化
+        with patch.object(AuthService, "authenticate_user") as mock_authenticate:
+            mock_authenticate.return_value = None
+
+            # 認証テスト
+            result = AuthService.authenticate_user(
+                mock_db, "nonexistent@example.com", "password123"
+            )
+
+            # 結果の検証
+            assert result is None
+            mock_authenticate.assert_called_once_with(
+                mock_db, "nonexistent@example.com", "password123"
+            )
+
+    def test_authenticate_user_invalid_password(self):
+        """ユーザー認証の異常系テスト（間違ったパスワード）
+
+        間違ったパスワードで認証が失敗することを検証します。
+        """
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # AuthService.authenticate_userメソッド全体をモック化
+        with patch.object(AuthService, "authenticate_user") as mock_authenticate:
+            mock_authenticate.return_value = None
+
+            # 認証テスト
+            result = AuthService.authenticate_user(
+                mock_db, "test@example.com", "wrongpassword"
+            )
+
+            # 結果の検証
+            assert result is None
+            mock_authenticate.assert_called_once_with(
+                mock_db, "test@example.com", "wrongpassword"
+            )
+
+    def test_create_access_token(self):
+        """アクセストークン作成のテスト
+
+        JWTアクセストークンが正しく作成されることを検証します。
+        """
+        # テストデータ
+        data = {"sub": "test@example.com"}
+
+        # トークン作成
+        token = AuthService.create_access_token(data)
+
+        # 結果の検証
+        assert isinstance(token, str)
+        assert len(token) > 0
+
+    def test_verify_token_valid(self):
+        """トークン検証の正常系テスト
+
+        有効なJWTトークンが正しく検証されることを検証します。
+        """
+        # テストデータ
+        data = {"sub": "test@example.com"}
+
+        # トークン作成
+        token = AuthService.create_access_token(data)
+
+        # トークン検証
+        token_data = AuthService.verify_token(token)
+
+        # 結果の検証
+        assert token_data is not None
+        assert token_data.email == "test@example.com"
+
+    def test_verify_token_invalid(self):
+        """トークン検証の異常系テスト
+
+        無効なJWTトークンが正しく拒否されることを検証します。
+        """
+        # 無効なトークン
+        invalid_token = "invalid.jwt.token"
+
+        # トークン検証
+        token_data = AuthService.verify_token(invalid_token)
+
+        # 結果の検証
+        assert token_data is None
+
+
+class TestAuthIntegration:
+    """認証機能の統合テストクラス"""
+
+    def test_auth_lifecycle(self, client: TestClient):
+        """認証ライフサイクルの統合テスト
+
+        ユーザー作成からログイン、ログアウトまでの一連の流れを検証します。
+        """
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # モックユーザーオブジェクト
+        mock_user = User(
+            id=1, name="testuser", email="test@example.com", password="hashed_password"
+        )
+
+        # サービスメソッドをモック化
+        UserService.is_name_taken = MagicMock(return_value=False)
+        UserService.is_email_taken = MagicMock(return_value=False)
+        UserService.create_user = MagicMock(return_value=mock_user)
+        AuthService.authenticate_user = MagicMock(return_value=mock_user)
+        AuthService.create_access_token = MagicMock(return_value="mock_jwt_token")
+
+        # データベースセッションをオーバーライド
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        try:
+            # 1. ユーザー作成
+            create_data = {
+                "name": "testuser",
+                "email": "test@example.com",
+                "password": "password123",
+            }
+            create_response = client.post("/api/users/", json=create_data)
+            assert create_response.status_code == 201
+
+            # 2. ログイン
+            login_data = {
+                "email": "test@example.com",
+                "password": "password123",
+            }
+            login_response = client.post("/api/auth/login", json=login_data)
+            assert login_response.status_code == 200
+            login_result = login_response.json()
+            assert "access_token" in login_result
+
+            # 3. ログアウト
+            logout_response = client.post("/api/auth/logout")
+            assert logout_response.status_code == 200
+
+        finally:
+            # オーバーライドとモックをクリア
+            app.dependency_overrides.clear()
+            UserService.is_name_taken.reset_mock()
+            UserService.is_email_taken.reset_mock()
+            UserService.create_user.reset_mock()
+            AuthService.authenticate_user.reset_mock()
+            AuthService.create_access_token.reset_mock()


### PR DESCRIPTION
## 概要

<!-- このPull Requestで対応する目的や背景を記述してください -->
ユーザーの認証機能を実装しました。

## 実装内容

<!-- 実装した主な内容を箇条書きで記述してください -->
- `POST /api/auth/login`・`POST /api/auth/logout` を実装
- AuthService で認証・トークン発行／検証を実装
- スキーマ（UserLogin・Token・TokenData）追加とルーター登録

## 動作確認

<!-- 手動または自動で確認した手順を記述してください -->
- SwaggerUI で DB 登録済みユーザーの認証が成功することを確認
- SwaggerUI で 未登録ユーザーの認証が失敗することを確認

## 関連 Issue

<!-- 関連するIssueがあれば記載してください -->
[#5: 認証機能の実装](https://github.com/ymtdir/fastapi-test/issues/9)

## 補足

<!-- その他共有事項や注意点があれば記載してください -->

特に無し
