### PR TITLE
#6: ユーザーのCRUD操作

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,8 @@ pytest==7.4.3
 pytest-cov==4.1.0
 flake8==6.1.0
 httpx==0.25.2 
-psycopg2-binary==2.9.9
-sqlalchemy==2.0.23
+psycopg2-binary==2.9.10
+sqlalchemy==2.0.43
 pydantic-settings==2.0.0
 passlib[bcrypt]>=1.7.4
 python-jose[cryptography]>=3.3.0

--- a/schemas/users.py
+++ b/schemas/users.py
@@ -3,7 +3,8 @@
 リクエスト/レスポンスのバリデーションとシリアライゼーションを行います。
 """
 
-from pydantic import BaseModel, Field
+from typing import Optional
+from pydantic import BaseModel, Field, EmailStr
 
 
 class UserCreate(BaseModel):
@@ -58,4 +59,40 @@ class UserResponse(BaseModel):
         # JSON Schema用のサンプルデータ
         json_schema_extra = {
             "example": {"id": 1, "name": "user", "email": "user@example.com"}
+        }
+
+
+class UserUpdate(BaseModel):
+    """ユーザー更新用スキーマ
+
+    PUTリクエストで受け取るデータの形式を定義します。
+    名前・メールアドレスとパスワードの両方を更新可能です。
+
+    Attributes:
+        name: ユーザー名（オプション、3-50文字）
+        email: メールアドレス（オプション、有効なメール形式）
+        current_password: 現在のパスワード（パスワード変更時のみ必須）
+        new_password: 新しいパスワード（オプション、8文字以上）
+    """
+
+    name: Optional[str] = Field(
+        None, min_length=3, max_length=50, description="ユーザー名"
+    )
+    email: Optional[EmailStr] = Field(None, description="メールアドレス")
+    current_password: Optional[str] = Field(None, description="現在のパスワード")
+    new_password: Optional[str] = Field(
+        None, min_length=8, description="新しいパスワード"
+    )
+
+    class Config:
+        """設定クラス"""
+
+        # JSON Schema用のサンプルデータ
+        json_schema_extra = {
+            "example": {
+                "name": "updated_user",
+                "email": "updated@example.com",
+                "current_password": "oldpassword",
+                "new_password": "newpassword123",
+            }
         }

--- a/services/users.py
+++ b/services/users.py
@@ -3,12 +3,12 @@
 ユーザー関連のビジネスロジックを処理します。
 """
 
-from typing import Optional
+from typing import Optional, List
 from sqlalchemy.orm import Session
 from sqlalchemy.exc import IntegrityError
 from passlib.context import CryptContext
 from models.user import User
-from schemas.users import UserCreate
+from schemas.users import UserCreate, UserUpdate
 
 # パスワードハッシュ化用の設定
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
@@ -129,3 +129,87 @@ class UserService:
             bool: パスワードが一致する場合True
         """
         return pwd_context.verify(plain_password, hashed_password)
+
+    @staticmethod
+    def get_all_users(db: Session) -> List[User]:
+        """すべてのユーザーを取得する
+
+        Args:
+            db: データベースセッション
+
+        Returns:
+            List[User]: ユーザーリスト
+        """
+        return db.query(User).all()
+
+    @staticmethod
+    def update_user(db: Session, user_id: int, user_data: UserUpdate) -> Optional[User]:
+        """ユーザー情報を更新する
+
+        Args:
+            db: データベースセッション
+            user_id: ユーザーID
+            user_data: 更新データ
+
+        Returns:
+            Optional[User]: 更新されたユーザーオブジェクト（存在しない場合はNone）
+
+        Raises:
+            IntegrityError: ユーザー名またはメールアドレスが重複している場合
+            ValueError: パスワード変更時に現在のパスワードが正しくない場合
+        """
+        db_user = UserService.get_user_by_id(db, user_id)
+        if not db_user:
+            return None
+
+        # 更新データがある場合のみ更新
+        update_data = user_data.model_dump(exclude_unset=True)
+
+        # パスワード変更の処理
+        if "new_password" in update_data:
+            # 新しいパスワードが指定されている場合、現在のパスワードが必要
+            if "current_password" not in update_data:
+                raise ValueError("パスワードを変更する場合は現在のパスワードが必要です")
+
+            # 現在のパスワードを検証
+            if not UserService.verify_password(
+                update_data["current_password"], db_user.password
+            ):
+                raise ValueError("現在のパスワードが正しくありません")
+
+            # 新しいパスワードをハッシュ化
+            update_data["password"] = pwd_context.hash(update_data["new_password"])
+
+            # パスワード関連のフィールドを削除
+            update_data.pop("current_password", None)
+            update_data.pop("new_password", None)
+
+        try:
+            for field, value in update_data.items():
+                setattr(db_user, field, value)
+
+            db.commit()
+            db.refresh(db_user)
+            return db_user
+        except IntegrityError:
+            db.rollback()
+            raise
+
+    @staticmethod
+    def delete_user(db: Session, user_id: int) -> bool:
+        """ユーザーを削除する
+
+        Args:
+            db: データベースセッション
+            user_id: ユーザーID
+
+        Returns:
+            bool: 削除成功の場合True、ユーザーが存在しない場合False
+        """
+        db_user = UserService.get_user_by_id(db, user_id)
+        if not db_user:
+            return False
+
+        db.delete(db_user)
+        db.commit()
+        return True

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -255,3 +255,438 @@ class TestCreateUser:
             UserService.is_name_taken.reset_mock()
             UserService.is_email_taken.reset_mock()
             UserService.create_user.reset_mock()
+
+
+class TestGetUsers:
+    """ユーザー一覧取得エンドポイントのテストクラス"""
+
+    def test_get_users_success(self, client: TestClient):
+        """ユーザー一覧取得の正常系テスト
+
+        正常にユーザー一覧が取得できることを検証します。
+        """
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # モックユーザーリスト
+        mock_users = [
+            User(id=1, name="user1", email="user1@example.com", password="hashed1"),
+            User(id=2, name="user2", email="user2@example.com", password="hashed2"),
+        ]
+
+        # UserServiceのメソッドをモック化
+        UserService.get_all_users = MagicMock(return_value=mock_users)
+
+        # データベースセッションをオーバーライド
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        try:
+            # APIリクエストを送信
+            response = client.get("/api/users/")
+
+            # レスポンスの検証
+            assert response.status_code == 200
+            response_data = response.json()
+            assert len(response_data) == 2
+            assert response_data[0]["id"] == 1
+            assert response_data[0]["name"] == "user1"
+            assert response_data[0]["email"] == "user1@example.com"
+            assert response_data[1]["id"] == 2
+            assert response_data[1]["name"] == "user2"
+            assert response_data[1]["email"] == "user2@example.com"
+
+            # パスワードが含まれていないことを確認
+            for user in response_data:
+                assert "password" not in user
+
+            # サービスメソッドの呼び出し確認
+            UserService.get_all_users.assert_called_once_with(mock_db)
+
+        finally:
+            # オーバーライドとモックをクリア
+            app.dependency_overrides.clear()
+            UserService.get_all_users.reset_mock()
+
+
+class TestGetUser:
+    """ユーザー詳細取得エンドポイントのテストクラス"""
+
+    def test_get_user_success(self, client: TestClient):
+        """ユーザー詳細取得の正常系テスト
+
+        存在するユーザーIDで正常にユーザー詳細が取得できることを検証します。
+        """
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # モックユーザーオブジェクト
+        mock_user = User(
+            id=1, name="testuser", email="test@example.com", password="hashed_password"
+        )
+
+        # UserServiceのメソッドをモック化
+        UserService.get_user_by_id = MagicMock(return_value=mock_user)
+
+        # データベースセッションをオーバーライド
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        try:
+            # APIリクエストを送信
+            response = client.get("/api/users/1")
+
+            # レスポンスの検証
+            assert response.status_code == 200
+            response_data = response.json()
+            assert response_data["id"] == 1
+            assert response_data["name"] == "testuser"
+            assert response_data["email"] == "test@example.com"
+            assert "password" not in response_data  # パスワードは含まれない
+
+            # サービスメソッドの呼び出し確認
+            UserService.get_user_by_id.assert_called_once_with(mock_db, 1)
+
+        finally:
+            # オーバーライドとモックをクリア
+            app.dependency_overrides.clear()
+            UserService.get_user_by_id.reset_mock()
+
+    def test_get_user_not_found(self, client: TestClient):
+        """ユーザー詳細取得の異常系テスト（ユーザーが存在しない）
+
+        存在しないユーザーIDでリクエストした場合のエラーハンドリングを検証します。
+        """
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # UserServiceのメソッドをモック化（ユーザーが見つからない）
+        UserService.get_user_by_id = MagicMock(return_value=None)
+
+        # データベースセッションをオーバーライド
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        try:
+            # APIリクエストを送信
+            response = client.get("/api/users/999")
+
+            # エラーレスポンスの検証
+            assert response.status_code == 404
+            response_data = response.json()
+            assert "999" in response_data["detail"]
+            assert "見つかりません" in response_data["detail"]
+
+            # サービスメソッドの呼び出し確認
+            UserService.get_user_by_id.assert_called_once_with(mock_db, 999)
+
+        finally:
+            # オーバーライドとモックをクリア
+            app.dependency_overrides.clear()
+            UserService.get_user_by_id.reset_mock()
+
+
+class TestUpdateUser:
+    """ユーザー更新エンドポイントのテストクラス"""
+
+    def test_update_user_info_success(self, client: TestClient):
+        """ユーザー情報更新の正常系テスト（パスワード変更なし）
+
+        名前とメールアドレスのみを更新した場合の正常系を検証します。
+        """
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # モックユーザーオブジェクト（更新後）
+        mock_updated_user = User(
+            id=1,
+            name="updated_user",
+            email="updated@example.com",
+            password="hashed_password",
+        )
+
+        # UserServiceのメソッドをモック化
+        UserService.update_user = MagicMock(return_value=mock_updated_user)
+
+        # データベースセッションをオーバーライド
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        try:
+            # テストデータ（パスワード変更なし）
+            request_data = {
+                "name": "updated_user",
+                "email": "updated@example.com",
+            }
+
+            # APIリクエストを送信
+            response = client.put("/api/users/1", json=request_data)
+
+            # レスポンスの検証
+            assert response.status_code == 200
+            response_data = response.json()
+            assert response_data["id"] == 1
+            assert response_data["name"] == "updated_user"
+            assert response_data["email"] == "updated@example.com"
+            assert "password" not in response_data
+
+            # サービスメソッドの呼び出し確認
+            UserService.update_user.assert_called_once()
+
+        finally:
+            # オーバーライドとモックをクリア
+            app.dependency_overrides.clear()
+            UserService.update_user.reset_mock()
+
+    def test_update_user_password_success(self, client: TestClient):
+        """ユーザーパスワード更新の正常系テスト
+
+        パスワードのみを更新した場合の正常系を検証します。
+        """
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # モックユーザーオブジェクト（更新後）
+        mock_updated_user = User(
+            id=1,
+            name="testuser",
+            email="test@example.com",
+            password="new_hashed_password",
+        )
+
+        # UserServiceのメソッドをモック化
+        UserService.update_user = MagicMock(return_value=mock_updated_user)
+
+        # データベースセッションをオーバーライド
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        try:
+            # テストデータ（パスワード変更のみ）
+            request_data = {
+                "current_password": "oldpassword",
+                "new_password": "newpassword123",
+            }
+
+            # APIリクエストを送信
+            response = client.put("/api/users/1", json=request_data)
+
+            # レスポンスの検証
+            assert response.status_code == 200
+            response_data = response.json()
+            assert response_data["id"] == 1
+            assert response_data["name"] == "testuser"
+            assert response_data["email"] == "test@example.com"
+            assert "password" not in response_data
+
+            # サービスメソッドの呼び出し確認
+            UserService.update_user.assert_called_once()
+
+        finally:
+            # オーバーライドとモックをクリア
+            app.dependency_overrides.clear()
+            UserService.update_user.reset_mock()
+
+    def test_update_user_not_found(self, client: TestClient):
+        """ユーザー更新の異常系テスト（ユーザーが存在しない）
+
+        存在しないユーザーIDで更新リクエストした場合のエラーハンドリングを検証します。
+        """
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # UserServiceのメソッドをモック化（ユーザーが見つからない）
+        UserService.update_user = MagicMock(return_value=None)
+
+        # データベースセッションをオーバーライド
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        try:
+            # テストデータ
+            request_data = {
+                "name": "updated_user",
+            }
+
+            # APIリクエストを送信
+            response = client.put("/api/users/999", json=request_data)
+
+            # エラーレスポンスの検証
+            assert response.status_code == 404
+            response_data = response.json()
+            assert "999" in response_data["detail"]
+            assert "見つかりません" in response_data["detail"]
+
+            # サービスメソッドの呼び出し確認
+            UserService.update_user.assert_called_once()
+
+        finally:
+            # オーバーライドとモックをクリア
+            app.dependency_overrides.clear()
+            UserService.update_user.reset_mock()
+
+    def test_update_user_password_error(self, client: TestClient):
+        """ユーザー更新の異常系テスト（パスワードエラー）
+
+        現在のパスワードが間違っている場合のエラーハンドリングを検証します。
+        """
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # UserServiceのメソッドをモック化（パスワードエラー）
+        UserService.update_user = MagicMock(
+            side_effect=ValueError("現在のパスワードが正しくありません")
+        )
+
+        # データベースセッションをオーバーライド
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        try:
+            # テストデータ（間違った現在のパスワード）
+            request_data = {
+                "current_password": "wrongpassword",
+                "new_password": "newpassword123",
+            }
+
+            # APIリクエストを送信
+            response = client.put("/api/users/1", json=request_data)
+
+            # エラーレスポンスの検証
+            assert response.status_code == 400
+            response_data = response.json()
+            assert "現在のパスワードが正しくありません" in response_data["detail"]
+
+            # サービスメソッドの呼び出し確認
+            UserService.update_user.assert_called_once()
+
+        finally:
+            # オーバーライドとモックをクリア
+            app.dependency_overrides.clear()
+            UserService.update_user.reset_mock()
+
+    def test_update_user_duplicate_error(self, client: TestClient):
+        """ユーザー更新の異常系テスト（重複エラー）
+
+        重複するユーザー名やメールアドレスで更新した場合のエラーハンドリングを検証します。
+        """
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # UserServiceのメソッドをモック化（重複エラー）
+        UserService.update_user = MagicMock(side_effect=IntegrityError("", "", ""))
+
+        # データベースセッションをオーバーライド
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        try:
+            # テストデータ
+            request_data = {
+                "name": "duplicate_user",
+                "email": "duplicate@example.com",
+            }
+
+            # APIリクエストを送信
+            response = client.put("/api/users/1", json=request_data)
+
+            # エラーレスポンスの検証
+            assert response.status_code == 400
+            response_data = response.json()
+            assert "既に使用されています" in response_data["detail"]
+
+            # サービスメソッドの呼び出し確認
+            UserService.update_user.assert_called_once()
+
+        finally:
+            # オーバーライドとモックをクリア
+            app.dependency_overrides.clear()
+            UserService.update_user.reset_mock()
+
+
+class TestDeleteUser:
+    """ユーザー削除エンドポイントのテストクラス"""
+
+    def test_delete_user_success(self, client: TestClient):
+        """ユーザー削除の正常系テスト
+
+        存在するユーザーIDで正常にユーザーが削除できることを検証します。
+        """
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # UserServiceのメソッドをモック化
+        UserService.delete_user = MagicMock(return_value=True)
+
+        # データベースセッションをオーバーライド
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        try:
+            # APIリクエストを送信
+            response = client.delete("/api/users/1")
+
+            # レスポンスの検証
+            assert response.status_code == 204
+            assert response.content == b""  # 空のレスポンスボディ
+
+            # サービスメソッドの呼び出し確認
+            UserService.delete_user.assert_called_once_with(mock_db, 1)
+
+        finally:
+            # オーバーライドとモックをクリア
+            app.dependency_overrides.clear()
+            UserService.delete_user.reset_mock()
+
+    def test_delete_user_not_found(self, client: TestClient):
+        """ユーザー削除の異常系テスト（ユーザーが存在しない）
+
+        存在しないユーザーIDで削除リクエストした場合のエラーハンドリングを検証します。
+        """
+        # モックデータベースセッション
+        mock_db = MagicMock()
+
+        # UserServiceのメソッドをモック化（ユーザーが見つからない）
+        UserService.delete_user = MagicMock(return_value=False)
+
+        # データベースセッションをオーバーライド
+        def override_get_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = override_get_db
+
+        try:
+            # APIリクエストを送信
+            response = client.delete("/api/users/999")
+
+            # エラーレスポンスの検証
+            assert response.status_code == 404
+            response_data = response.json()
+            assert "999" in response_data["detail"]
+            assert "見つかりません" in response_data["detail"]
+
+            # サービスメソッドの呼び出し確認
+            UserService.delete_user.assert_called_once_with(mock_db, 999)
+
+        finally:
+            # オーバーライドとモックをクリア
+            app.dependency_overrides.clear()
+            UserService.delete_user.reset_mock()


### PR DESCRIPTION
## 概要

<!-- このPull Requestで対応する目的や背景を記述してください -->
ユーザー管理システムのCRUD機能を完全に実装しました。
これまでユーザー作成機能のみだったシステムに、ユーザー一覧取得、詳細取得、更新、削除機能を追加し、完全なユーザー管理APIを構築しました。

## 実装内容

<!-- 実装した主な内容を箇条書きで記述してください -->
- ユーザー一覧取得APIエンドポイント（GET /api/users/）の追加
- ユーザー詳細取得APIエンドポイント（GET /api/users/{user_id}）の追加
- ユーザー更新APIエンドポイント（PUT /api/users/{user_id}）の追加
- ユーザー削除APIエンドポイント（DELETE /api/users/{user_id}）の追加
- UserUpdateスキーマの追加（名前・メール・パスワードの部分更新対応）
- ユーザーサービスクラスにCRUD操作メソッドを追加
- 

## 動作確認

<!-- 手動または自動で確認した手順を記述してください -->
- [x] ユーザー一覧取得APIで全ユーザーを取得できる
- [x] ユーザー詳細取得APIで特定ユーザーの情報を取得できる
- [x] 存在しないユーザーIDで404エラーが返される
- [x] ユーザー情報更新APIで名前・メールアドレスを更新できる
- [x] パスワード変更時に現在のパスワード検証が機能する
- [x] 間違った現在パスワードで400エラーが返される
- [x] 重複するメールアドレスで400エラーが返される
- [x] ユーザー削除APIでユーザーを削除できる
- [x] 存在しないユーザーIDで削除時に404エラーが返される

## 関連 Issue

<!-- 関連するIssueがあれば記載してください -->
[#6: ユーザーのCRUD操作](https://github.com/ymtdir/fastapi-test/issues/11)

## 補足

<!-- その他共有事項や注意点があれば記載してください -->

特に無し
