### PR TITLE
#7: ユーザー名の重複を許可 

### DIFF
--- a/routers/users.py
+++ b/routers/users.py
@@ -43,24 +43,17 @@ async def create_user(
         UserResponse: 作成されたユーザー情報
 
     Raises:
-        HTTPException: ユーザー名またはメールアドレスが重複している場合（400）
+        HTTPException: メールアドレスが重複している場合（400）
     """
 
-    # 1. ユーザー名の重複チェック
-    if UserService.is_name_taken(db, user_data.name):
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"ユーザー名 '{user_data.name}' は既に使用されています",
-        )
-
-    # 2. メールアドレスの重複チェック
+    # 1. メールアドレスの重複チェック
     if UserService.is_email_taken(db, user_data.email):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"メールアドレス '{user_data.email}' は既に使用されています",
         )
 
-    # 3. ユーザー作成
+    # 2. ユーザー作成
     try:
         db_user = UserService.create_user(db, user_data)
         return UserResponse.model_validate(db_user)
@@ -68,7 +61,7 @@ async def create_user(
         # データベースレベルでの制約違反（念のため）
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="ユーザー名またはメールアドレスが既に使用されています",
+            detail="メールアドレスが既に使用されています",
         )
 
 
@@ -146,7 +139,7 @@ async def update_user(
     Raises:
         HTTPException: ユーザーが存在しない場合（404）
         HTTPException: パスワード変更時に現在のパスワードが正しくない場合（400）
-        HTTPException: ユーザー名またはメールアドレスが重複している場合（400）
+        HTTPException: メールアドレスが重複している場合（400）
     """
 
     try:
@@ -170,7 +163,7 @@ async def update_user(
         # データベース制約違反（重複エラー）
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="ユーザー名またはメールアドレスが既に使用されています",
+            detail="メールアドレスが既に使用されています",
         )
 
 

--- a/schemas/users.py
+++ b/schemas/users.py
@@ -13,7 +13,7 @@ class UserCreate(BaseModel):
     POSTリクエストで受け取るデータの形式を定義します。
 
     Attributes:
-        name: ユーザー名（必須、3-50文字）
+        name: ユーザー名（必須、3-50文字、重複可能）
         email: メールアドレス（必須、有効なメール形式）
         password: パスワード（必須、8文字以上）
     """
@@ -69,7 +69,7 @@ class UserUpdate(BaseModel):
     名前・メールアドレスとパスワードの両方を更新可能です。
 
     Attributes:
-        name: ユーザー名（オプション、3-50文字）
+        name: ユーザー名（オプション、3-50文字、重複可能）
         email: メールアドレス（オプション、有効なメール形式）
         current_password: 現在のパスワード（パスワード変更時のみ必須）
         new_password: 新しいパスワード（オプション、8文字以上）

--- a/services/users.py
+++ b/services/users.py
@@ -32,7 +32,7 @@ class UserService:
             User: 作成されたユーザーオブジェクト
 
         Raises:
-            IntegrityError: ユーザー名またはメールアドレスが重複している場合
+            IntegrityError: メールアドレスが重複している場合
         """
         # パスワードをハッシュ化
         hashed_password = pwd_context.hash(user_data.password)
@@ -92,19 +92,6 @@ class UserService:
         return db.query(User).filter(User.email == email).first()
 
     @staticmethod
-    def is_name_taken(db: Session, name: str) -> bool:
-        """ユーザー名が既に使用されているかチェックする
-
-        Args:
-            db: データベースセッション
-            name: チェックするユーザー名
-
-        Returns:
-            bool: 使用済みの場合True、利用可能な場合False
-        """
-        return UserService.get_user_by_name(db, name) is not None
-
-    @staticmethod
     def is_email_taken(db: Session, email: str) -> bool:
         """メールアドレスが既に使用されているかチェックする
 
@@ -155,7 +142,7 @@ class UserService:
             Optional[User]: 更新されたユーザーオブジェクト（存在しない場合はNone）
 
         Raises:
-            IntegrityError: ユーザー名またはメールアドレスが重複している場合
+            IntegrityError: メールアドレスが重複している場合
             ValueError: パスワード変更時に現在のパスワードが正しくない場合
         """
         db_user = UserService.get_user_by_id(db, user_id)


### PR DESCRIPTION
## 概要

<!-- このPull Requestで対応する目的や背景を記述してください -->
ユーザー名の重複チェック機能を削除し、メールアドレスのみをユニーク制約として維持するように変更しました。
これにより、同じユーザー名を持つユーザーを複数登録できるようになります。

## 実装内容

<!-- 実装した主な内容を箇条書きで記述してください -->
- ユーザー作成時のユーザー名重複チェック処理を削除
- ユーザー更新時のユーザー名重複チェック処理を削除
- UserService.is_name_takenメソッドを削除

## 動作確認

<!-- 手動または自動で確認した手順を記述してください -->
- [x] 同じユーザー名で複数のユーザーを作成できる
- [x] メールアドレスの重複チェックは正常に動作する
- [x] ユーザー更新時にメールアドレスの重複チェックが動作する

## 関連 Issue

<!-- 関連するIssueがあれば記載してください -->
[#7: ユーザー名の重複を許可 ](https://github.com/ymtdir/fastapi-test/issues/13)

## 補足

<!-- その他共有事項や注意点があれば記載してください -->

特に無し
